### PR TITLE
A bit more cleaning

### DIFF
--- a/mttl/models/containers/__init__.py
+++ b/mttl/models/containers/__init__.py
@@ -154,10 +154,9 @@ def replace_selector_for_container(
                         break
 
     if not expert_containers:
-        logger.warn(
+        raise ValueError(
             f"No expert containers found for modifier type: {modifier_name}. Cannot assign a selector! Load some experts beforehand."
         )
-        return 0, 0
 
     if force_replace:
         for container in expert_containers:

--- a/mttl/models/containers/__init__.py
+++ b/mttl/models/containers/__init__.py
@@ -1,4 +1,5 @@
 import re
+from typing import Tuple
 
 from mttl.config import Config
 from mttl.logging import logger
@@ -132,7 +133,7 @@ def replace_selector_for_container(
     selector_config: SelectorConfig,
     selector_cache: SelectorsCache,
     force_replace: bool = False,
-):
+) -> Tuple[int, int]:
     """
     Assigns a selector to the expert containers in the transformer model.
     """
@@ -153,9 +154,10 @@ def replace_selector_for_container(
                         break
 
     if not expert_containers:
-        raise ValueError(
+        logger.warn(
             f"No expert containers found for modifier type: {modifier_name}. Cannot assign a selector! Load some experts beforehand."
         )
+        return 0, 0
 
     if force_replace:
         for container in expert_containers:

--- a/mttl/models/containers/__init__.py
+++ b/mttl/models/containers/__init__.py
@@ -89,8 +89,8 @@ def create_selector_for_container(
     transformer,
     container,
     modifier_name: str,
-    selector_config: SelectorConfig,
-    selector_cache: SelectorsCache,
+    selector_config: SelectorConfig = None,
+    selector_cache: SelectorsCache = None,
 ) -> Selector:
     if container.selector is not None and container.selector.config == selector_config:
         # selector already exists and has the same config
@@ -130,8 +130,8 @@ def create_selector_for_container(
 def replace_selector_for_container(
     transformer,
     modifier_name: str,
-    selector_config: SelectorConfig,
-    selector_cache: SelectorsCache,
+    selector_config: SelectorConfig = None,
+    selector_cache: SelectorsCache = None,
     force_replace: bool = False,
 ) -> Tuple[int, int]:
     """

--- a/mttl/models/containers/__init__.py
+++ b/mttl/models/containers/__init__.py
@@ -87,7 +87,7 @@ def filter_expert_weights(layer_name, expert_weights):
 def create_selector_for_container(
     transformer,
     container,
-    modifier_type: str,
+    modifier_name: str,
     selector_config: SelectorConfig,
     selector_cache: SelectorsCache,
 ) -> Selector:
@@ -102,8 +102,8 @@ def create_selector_for_container(
     # we create a new selector if it doesn't exist for this identifier, or
     # if we are replacing a previous one of a different type
     create_new_selector = (
-        not selector_cache.get(modifier_type, identifier)
-        or selector_cache.get(modifier_type, identifier).config != selector_config
+        not selector_cache.get(modifier_name, identifier)
+        or selector_cache.get(modifier_name, identifier).config != selector_config
     )
     if create_new_selector:
         # Special case when you have a decoder layer in an enc-dec model
@@ -111,12 +111,12 @@ def create_selector_for_container(
             selector_config,
             layer=container.layer,
         )
-        selector_cache.insert(modifier_type, identifier, selector)
+        selector_cache.insert(modifier_name, identifier, selector)
 
         # selector needs to know how many times it will be called per forward pass in order to be able to reset the cache
         selector.total_calls_per_forward += 1
     else:
-        selector: Selector = selector_cache.get(modifier_type, identifier)
+        selector: Selector = selector_cache.get(modifier_name, identifier)
         # selector needs to know how many times it will be called per forward pass in order to be able to reset the cache
         selector.total_calls_per_forward += 1
         selector = selector.create_view()
@@ -128,7 +128,7 @@ def create_selector_for_container(
 
 def replace_selector_for_container(
     transformer,
-    modifier_type: str,
+    modifier_name: str,
     selector_config: SelectorConfig,
     selector_cache: SelectorsCache,
     force_replace: bool = False,
@@ -146,7 +146,7 @@ def replace_selector_for_container(
                         supports_config
                     )
                     # selector does not apply to this container
-                    if not container_modifier == modifier_type:
+                    if not container_modifier == modifier_name:
                         continue
                     else:
                         expert_containers.append(layer)
@@ -154,13 +154,13 @@ def replace_selector_for_container(
 
     if not expert_containers:
         raise ValueError(
-            f"No expert containers found for modifier type: {modifier_type}. Cannot assign a selector! Load some experts beforehand."
+            f"No expert containers found for modifier type: {modifier_name}. Cannot assign a selector! Load some experts beforehand."
         )
 
     if force_replace:
         for container in expert_containers:
             container.selector = None
-        selector_cache.clear(modifier_type)
+        selector_cache.clear(modifier_name)
 
     n_selectors = 0
     n_selectors_views = 0
@@ -169,7 +169,7 @@ def replace_selector_for_container(
         selector = create_selector_for_container(
             transformer,
             container,
-            modifier_type,
+            modifier_name,
             selector_config,
             selector_cache,
         )

--- a/mttl/models/containers/__init__.py
+++ b/mttl/models/containers/__init__.py
@@ -84,25 +84,6 @@ def filter_expert_weights(layer_name, expert_weights):
     return weights
 
 
-def add_expert_library_to_transformer(
-    transformer,
-    expert_library: ExpertLibrary,
-    action: str = "route",
-    default_expert: str = None,
-    selector_config: SelectorConfig = None,
-):
-    for expert_name, expert_dump in expert_library.items():
-        add_expert_to_transformer(
-            transformer,
-            expert_name,
-            expert_dump.expert_config,
-            expert_dump.expert_weights,
-            action=action,
-            is_default=expert_name == default_expert,
-            selector_config=selector_config,
-        )
-
-
 def create_selector_for_container(
     transformer,
     container,

--- a/mttl/models/containers/base.py
+++ b/mttl/models/containers/base.py
@@ -44,8 +44,18 @@ class ExpertContainer(nn.Module, Container):
         self.config = config
         self.layer = layer
         self.selector = selector or TaskNameSelector()
-        self.default_expert_name = None
+        self._default_expert_name = None
         self.expert_infos = {}
+
+    @property
+    def default_expert_name(self):
+        return self._default_expert_name
+
+    @default_expert_name.setter
+    def default_expert_name(self, value):
+        self._default_expert_name = value
+        if self.selector is not None:
+            self.selector.default_expert_name = value
 
     def assign_selector(self, selector: Selector) -> None:
         """Assigns a selector to this container."""

--- a/mttl/models/containers/lora_containers.py
+++ b/mttl/models/containers/lora_containers.py
@@ -274,15 +274,15 @@ class CoalescedLoRAExpertContainer(LoRAExpertContainer):
         weights: dict[str, Tensor] = self.experts.get_skill_weights(index_of)
 
         config = self.expert_infos[name].expert_config
-        modifier_type = get_modifier_name(config)
+        modifier_name = get_modifier_name(config)
 
-        if modifier_type == "lora":
+        if modifier_name == "lora":
             assert self.dummy_config.n_splits == 1
             # squeeze the first dimension and the n_splits dimension
             lora = LoRA(config, self.layer)
             lora.load_lora_weights({n: w.squeeze() for n, w in weights.items()})
             return lora
-        elif modifier_type == "skilled_lora":
+        elif modifier_name == "skilled_lora":
             # should be skilled lora
             skilled_lora = SkilledLoRA(config, self.layer)
             skilled_lora.load_lora_weights(weights)

--- a/mttl/models/containers/selectors/arrow_selector.py
+++ b/mttl/models/containers/selectors/arrow_selector.py
@@ -4,6 +4,7 @@ from mttl.models.containers.selectors.base import (
     PerTokenSelector,
     PerTokenSelectorConfig,
     Selector,
+    artifacts_cache,
 )
 
 
@@ -44,10 +45,12 @@ class ArrowSelectorConfig(PerTokenSelectorConfig):
 
 @Selector.register("arrow_router", ArrowSelectorConfig)
 class ArrowSelector(PerTokenSelector):
-    def _load_from_library(self):
+    @classmethod
+    @artifacts_cache
+    def load_from_library(cls, config):
         """Fetches prototypes from the library."""
         from mttl.models.library.library_transforms import ArrowConfig, ArrowTransform
 
-        return ArrowTransform(ArrowConfig(name=self.config.selector_data_id)).fetch(
-            self.config.library_id
+        return ArrowTransform(ArrowConfig(name=config.selector_data_id)).fetch(
+            config.library_id
         )

--- a/mttl/models/containers/selectors/average_activation_selector.py
+++ b/mttl/models/containers/selectors/average_activation_selector.py
@@ -4,6 +4,7 @@ from mttl.models.containers.selectors.base import (
     PerTokenSelector,
     PerTokenSelectorConfig,
     Selector,
+    artifacts_cache,
 )
 
 
@@ -49,7 +50,9 @@ class AverageActivationSelectorConfig(PerTokenSelectorConfig):
 
 @Selector.register("avg_act_router", AverageActivationSelectorConfig)
 class AverageActivationSelector(PerTokenSelector):
-    def _load_from_library(self):
+    @classmethod
+    @artifacts_cache
+    def load_from_library(cls, config):
         """Fetches prototypes from the library."""
         from mttl.models.library.library_transforms import (
             HiddenStateComputer,
@@ -57,5 +60,5 @@ class AverageActivationSelector(PerTokenSelector):
         )
 
         return HiddenStateComputer(
-            HiddenStateComputerConfig(name=self.config.selector_data_id)
-        ).fetch(self.config.library_id)
+            HiddenStateComputerConfig(name=config.selector_data_id)
+        ).fetch(config.library_id)

--- a/mttl/models/containers/selectors/base.py
+++ b/mttl/models/containers/selectors/base.py
@@ -168,6 +168,9 @@ class SelectorsCache:
             return self.cache[modifier_name]
         return self.cache[modifier_name].get(selector_name, None)
 
+    def keys(self):
+        return self.cache.keys()
+
     def items(self):
         return iter(self.cache.items())
 

--- a/mttl/models/containers/selectors/base.py
+++ b/mttl/models/containers/selectors/base.py
@@ -117,14 +117,10 @@ class MultiSelectorConfig(dict):
         return json.dumps({k: v.selector_name for k, v in self.items()})
 
     @classmethod
-    def create_default(cls, selector_config: SelectorConfig):
-        return cls({"lora": selector_config, "skilled_lora": selector_config})
-
-    @classmethod
     def from_training_config(
         cls,
         training_config: "Config",
-    ):
+    ) -> Union[SelectorConfig, "MultiSelectorConfig"]:
         import copy
         import json
 
@@ -134,10 +130,8 @@ class MultiSelectorConfig(dict):
         try:
             router_selector = json.loads(training_config.router_selector)
         except:
-            router_selector = {
-                "lora": training_config.router_selector,
-                "skilled_lora": training_config.router_selector,
-            }
+            # if not a json, assume it's a single selector
+            return SelectorConfig.from_training_config(training_config)
 
         selector_configs = cls()
         for modifier_name, selector_name in router_selector.items():

--- a/mttl/models/containers/selectors/base.py
+++ b/mttl/models/containers/selectors/base.py
@@ -117,6 +117,10 @@ class MultiSelectorConfig(dict):
         return json.dumps({k: v.selector_name for k, v in self.items()})
 
     @classmethod
+    def create_default(cls, selector_config: SelectorConfig):
+        return cls({"lora": selector_config, "skilled_lora": selector_config})
+
+    @classmethod
     def from_training_config(
         cls,
         training_config: "Config",
@@ -130,7 +134,10 @@ class MultiSelectorConfig(dict):
         try:
             router_selector = json.loads(training_config.router_selector)
         except:
-            router_selector = {Modifier.default: training_config.router_selector}
+            router_selector = {
+                "lora": training_config.router_selector,
+                "skilled_lora": training_config.router_selector,
+            }
 
         selector_configs = cls()
         for modifier_name, selector_name in router_selector.items():

--- a/mttl/models/containers/selectors/phatgoose_selector.py
+++ b/mttl/models/containers/selectors/phatgoose_selector.py
@@ -11,6 +11,7 @@ from mttl.models.containers.selectors.base import (
     PerTokenSelectorConfig,
     Selector,
     SelectorConfig,
+    artifacts_cache,
     forward_with_cache,
 )
 
@@ -63,7 +64,9 @@ class PhatgooseSelector(PerTokenSelector):
         if not self.config.lora_merge_after:
             logger.warning("PhatgooseSelector should have lora_merge_after=True")
 
-    def _load_from_library(self):
+    @classmethod
+    @artifacts_cache
+    def load_from_library(cls, config):
         """Fetches prototypes from the library."""
         from mttl.models.library.library_transforms import (
             PhatgooseConfig,

--- a/mttl/models/expert_context.py
+++ b/mttl/models/expert_context.py
@@ -45,7 +45,7 @@ class InfoContainer:
         return cls.local.context
 
     @classmethod
-    def wrap(cls, f):
+    def wrap_forward(cls, f):
         """
         Decorator method that wraps a ``forward()`` function of a model class.
         """

--- a/mttl/models/expert_model.py
+++ b/mttl/models/expert_model.py
@@ -351,8 +351,11 @@ class MultiExpertModel(ExpertModel):
         return containers
 
     @property
-    def selectors(self) -> Dict[str, Dict[str, Selector]]:
-        return self.selector_cache.cache
+    def selectors(self) -> Dict[str, List[Selector]]:
+        return {
+            key: list(self.selector_cache.get(key).values())
+            for key in self.selector_cache.keys()
+        }
 
     def delete_expert_container(self):
         """

--- a/mttl/models/expert_model.py
+++ b/mttl/models/expert_model.py
@@ -291,6 +291,15 @@ class MultiExpertModel(ExpertModel):
     def experts_names(self):
         return list(self.experts_infos.keys())
 
+    def set_default_expert(self, expert_name):
+        """Propagate default expert to all containers that contain it."""
+        if expert_name not in self.experts_infos:
+            raise ValueError(f"Expert {expert_name} not found in the model.")
+
+        for container in self.experts_containers:
+            if expert_name in container.expert_infos:
+                container.default_expert_name = expert_name
+
     @classmethod
     def from_pretrained_library(
         cls,

--- a/mttl/models/expert_model.py
+++ b/mttl/models/expert_model.py
@@ -511,7 +511,6 @@ class MultiExpertModel(ExpertModel):
             self.selector_cache,
             force_replace=True,
         )
-        assert self.selector_cache.get(modifier_name)
         logger.info(
             "Created {} selectors and {} views.".format(n_selectors, n_selectors_views)
         )
@@ -585,6 +584,11 @@ class MultiExpertModel(ExpertModel):
             expert = self.get_expert_instance(expert_name)
             library.add_expert(expert)
         return library
+
+    def as_expert(self):
+        raise NotImplementedError(
+            "This method is not implemented for MultiExpertModel."
+        )
 
 
 class MoEModel(MultiExpertModel):

--- a/mttl/models/expert_model.py
+++ b/mttl/models/expert_model.py
@@ -313,8 +313,10 @@ class MultiExpertModel(ExpertModel):
                 repo_id=library_id,
                 token=remote_token,
             )
+            repo_id = library_id
         else:
             library = library_id
+            repo_id = library_id.uri
 
         # get a config file from the library, and initialize the expert model
         an_expert = library[next(iter(library.keys()))]
@@ -325,7 +327,7 @@ class MultiExpertModel(ExpertModel):
         # set selector for the added experts
         if selector_config is not None:
             if isinstance(selector_config, LoadableSelectorConfig):
-                selector_config.library_id = library_id
+                selector_config.library_id = repo_id
 
             elif isinstance(selector_config, dict):
                 for modifier_name, cfg in selector_config.items():
@@ -334,7 +336,7 @@ class MultiExpertModel(ExpertModel):
                         isinstance(cfg, LoadableSelectorConfig)
                         and cfg.library_id is None
                     ):
-                        cfg.library_id = library_id
+                        cfg.library_id = repo_id
         else:
             logger.info("No selector config provided, assuming expert name selector!")
 

--- a/mttl/models/expert_model.py
+++ b/mttl/models/expert_model.py
@@ -505,7 +505,6 @@ class MultiExpertModel(ExpertModel):
     ):
         from mttl.models.containers import replace_selector_for_container
 
-        selector_config = self._get_selector_config(modifier_name)
         n_selectors, n_selectors_views = replace_selector_for_container(
             self.model,
             modifier_name,

--- a/mttl/models/expert_model.py
+++ b/mttl/models/expert_model.py
@@ -268,13 +268,13 @@ class ExpertModel(EfficientCheckpointModule):
 class MultiExpertModel(ExpertModel):
     """Adds all functions and properties for a multi-expert model."""
 
-    def __init__(self, model=None, selector_config=None, **config_kwargs):
+    def __init__(self, selector_config=None, **config_kwargs):
         config_kwargs["model_modifier"] = None
 
-        super().__init__(model=model, **config_kwargs)
+        super().__init__(**config_kwargs)
 
         # config about the routing
-        if "selector_config" in config_kwargs:
+        if selector_config is not None:
             self.selector_config = selector_config
         else:
             self.selector_config = MultiSelectorConfig.from_training_config(
@@ -338,7 +338,7 @@ class MultiExpertModel(ExpertModel):
         else:
             logger.info("No selector config provided, assuming expert name selector!")
 
-        model = cls(**vars(train_cfg), selector_config=selector_config, **kwargs)
+        model = cls(selector_config=selector_config, **vars(train_cfg))
         model.add_experts_from_library(library)
         return model
 

--- a/mttl/models/library/expert_library.py
+++ b/mttl/models/library/expert_library.py
@@ -660,11 +660,12 @@ class ExpertLibrary:
         return self._uri
 
     @staticmethod
-    def _remove_protocol(repo_id):
+    def _remove_protocol(repo_id) -> Tuple[str, str]:
         """Remove the protocol from the repo_id. Ex:
         az://storage_account/container -> storage_account/container
         """
-        return str(repo_id).split("://")
+        paths = str(repo_id).split("://")
+        return "hf" if len(paths) == 1 else paths[0], paths[-1]
 
     @property
     def sliced(self):

--- a/mttl/models/library/expert_library.py
+++ b/mttl/models/library/expert_library.py
@@ -624,7 +624,8 @@ class ExpertLibrary:
     ):
         super().__init__()
 
-        self.repo_id = self._remove_protocol(repo_id)
+        self.protocol, self.repo_id = self._remove_protocol(repo_id)
+        self._uri = repo_id
         self._sliced = False
         self.selection = selection
         self.exclude_selection = exclude_selection
@@ -654,12 +655,16 @@ class ExpertLibrary:
         self._build_lib()
         logger.info("Loaded %s experts from remote storage", len(self.data))
 
+    @property
+    def uri(self):
+        return self._uri
+
     @staticmethod
     def _remove_protocol(repo_id):
         """Remove the protocol from the repo_id. Ex:
         az://storage_account/container -> storage_account/container
         """
-        return str(repo_id).split("://")[-1]
+        return str(repo_id).split("://")
 
     @property
     def sliced(self):

--- a/mttl/models/modifiers/base.py
+++ b/mttl/models/modifiers/base.py
@@ -45,7 +45,7 @@ class ModifierConfig(object):
 
         data = asdict(self)
         # store the model modifier for easy loading
-        data["__model_modifier__"] = Modifier.get_name_by_config_class(type(self))
+        data["__model_modifier__"] = self.modifier_name
         return data
 
     @classmethod
@@ -56,6 +56,10 @@ class ModifierConfig(object):
             )
         mod = dumped.pop("__model_modifier__")
         return Modifier.get_config_class_by_name(mod)(**dumped)
+
+    @property
+    def modifier_name(self):
+        return Modifier.get_name_by_config_class(type(self))
 
     @staticmethod
     def from_training_config(

--- a/mttl/models/modifiers/base.py
+++ b/mttl/models/modifiers/base.py
@@ -10,6 +10,9 @@ from mttl.registrable import Registrable
 
 
 class Modifier(nn.Module, Registrable):
+    # default modifier
+    default = "lora"
+
     @property
     def layer_name(self):
         if not hasattr(self, "__layer_name__"):

--- a/projects/modular_llm/src/retrievers.py
+++ b/projects/modular_llm/src/retrievers.py
@@ -124,7 +124,8 @@ class LoraSimRetriever(Retriever):
         assert task_expert in expert_lib_copy
 
         module = copy.deepcopy(module)
-        module.load_from_module_dict(expert_lib_copy)
+        module.add_experts_from_library(expert_lib_copy)
+
         from torch.nn.functional import cosine_similarity
 
         task_module_name = task_expert.name

--- a/tests/test_expert_model.py
+++ b/tests/test_expert_model.py
@@ -29,30 +29,19 @@ def test_expert_model():
 
     # plug a poly selector
     model.set_selector("lora", PolySelectorConfig(task_names=["t1", "t2", "t3"]))
-    selector = list(model.selectors["lora"].values())[0]
+    selector = model.selectors["lora"][0]
     assert len(model.selectors["lora"]) == 12
     assert isinstance(selector, PolySelector)
 
     expert_a: Expert = model.get_expert_instance("a")
     assert len(expert_a.expert_weights) == 24
     assert expert_a.expert_config.modify_layers == ".*out_proj.*"
-    expert_merged = model.get_merged_expert(task_name="t1")
-    assert len(expert_merged.expert_weights) == 24
-    assert np.allclose(
-        sum([p.sum().item() for p in expert_merged.expert_weights.values()]),
-        -0.407,
-        atol=0.1,
-    )
 
     # switch selector for lora to task name
     model.set_selector("lora", TaskNameSelectorConfig())
 
-    # this should raise an error
-    with pytest.raises(NotImplementedError):
-        model.get_merged_expert()
-
     assert len(model.selectors["lora"]) == 12
-    assert isinstance(list(model.selectors["lora"].values())[0], TaskNameSelector)
+    assert isinstance(model.selectors["lora"][0], TaskNameSelector)
 
 
 def test_from_pretrained(tmp_path):
@@ -90,14 +79,14 @@ def test_from_pretrained_with_arrow(tmp_path):
     # from pretrained library
     selector_config = ArrowSelectorConfig(moe_top_k=4)
     model = MultiExpertModel.from_pretrained_library(
-        library, selector_configs={"lora": selector_config}
+        library, selector_config=selector_config
     )
     assert len(model.experts_names) == 2
     # the order might be different due to multi-threading in adding experts in parallel
     assert "a" in model.experts_names
     assert "b" in model.experts_names
 
-    selector = list(model.selectors["lora"].values())[0]
+    selector = model.selectors["lora"][0]
     assert selector.config == selector_config
     assert isinstance(selector, ArrowSelector)
     # loaded two experts

--- a/tests/test_routed_multi_expert_model.py
+++ b/tests/test_routed_multi_expert_model.py
@@ -78,7 +78,7 @@ class TestMultiExpertModel:
         module_dict = {"mod1": exp1_dest, "mod2": exp2_dest}
 
         module = MultiExpertModel(**vars(config))
-        module.load_from_module_dict(module_dict, action="merge")
+        module.add_experts_from_dict(module_dict, action="merge")
         bs, max_seq_len = 10, 100
 
         assert isinstance(
@@ -129,7 +129,7 @@ class TestMultiExpertModel:
             **vars(config),
         )
         assert module.hparams.model_modifier == None
-        module.load_from_module_dict(module_dict, action="route")
+        module.add_experts_from_dict(module_dict, action="route")
         bs, max_seq_len = 10, 100
 
         assert isinstance(
@@ -173,7 +173,7 @@ class TestMultiExpertModel:
             **vars(config),
         )
         assert module.hparams.model_modifier == None
-        module.load_from_module_dict(module_dict, action="route")
+        module.add_experts_from_dict(module_dict, action="route")
         self.nonzero_B_init(module)
 
         output = module(batch)
@@ -206,7 +206,7 @@ class TestMultiExpertModel:
 
         module = MultiExpertModel(**vars(config))
         assert module.hparams.model_modifier == None
-        module.load_from_module_dict(module_dict, action="route")
+        module.add_experts_from_dict(module_dict, action="route")
         bs, max_seq_len = 10, 100
 
         assert isinstance(
@@ -240,7 +240,7 @@ class TestMultiExpertModel:
         module_dict = {"mod1": exp1_dest, "mod2": exp2_dest}
 
         module = MultiExpertModel(**vars(config))
-        module.load_from_module_dict(module_dict, action="route")
+        module.add_experts_from_dict(module_dict, action="route")
         assert list(module.selectors["lora"].values())[0].init_gap == [-1e-3, 1e-3]
 
         assert isinstance(
@@ -292,7 +292,7 @@ class TestMultiExpertModel:
         module = MultiExpertModel(
             **vars(config),
         )
-        module.load_from_module_dict(module_dict)
+        module.add_experts_from_dict(module_dict)
         selector = list(module.selectors["lora"].values())[0]
         assert selector.init_gap == [0, 0]
         assert selector.module_logits_dict["mod1"].item() == 1.0
@@ -306,9 +306,6 @@ class TestMultiExpertModel:
             for selector in selector_dict.values():
                 weights[selector.layer_name] = selector.get_routing_weights()
         assert len(weights) > 1
-
-        expert = module.get_merged_expert()
-        assert isinstance(expert, Expert)
 
     def test_expert_selector_with_moe_routing_soft(
         self, mocker, tmp_exp_config, dummy_batch
@@ -486,7 +483,7 @@ class TestMultiExpertModel:
         module_dict = {"niv2_sentence_compression": exp1_dest, "niv2_misc": exp2_dest}
 
         module = MultiExpertModel(**vars(config))
-        module.load_from_module_dict(module_dict, action="route")
+        module.add_experts_from_dict(module_dict, action="route")
 
         bs, max_seq_len = 2, 100
         batch = {


### PR DESCRIPTION
- fixes MultiSelectorConfig stuff, now one can specify `router_selector: {'lora': X, 'hard_prompts': Y}`, if `router_selector: X` then this router is applied as a default to *any* modifiers inserted in the model

- wraps @artifacts_cache to avoid loading from library multiple times on the same selector class / config