### PR TITLE
Do not add special tokens while tokenizing

### DIFF
--- a/mttl/datamodule/base.py
+++ b/mttl/datamodule/base.py
@@ -256,7 +256,7 @@ class DefaultCollator(PackedMixin):
 
         # adds the eos token
         labels_ = [
-            l + ((" " + self.tokenizer.eos_token) if self.add_eos_to_targets else "")
+            l + ((self.tokenizer.eos_token) if self.add_eos_to_targets else "")
             for l in labels_
         ]
         return sources_, labels_
@@ -271,6 +271,7 @@ class DefaultCollator(PackedMixin):
                 padding=self.padding,
                 return_tensors=self.return_tensors,
                 truncation=True,
+                add_special_tokens=False,
             )
             tokenized_sources = self.tokenizer(
                 sources,
@@ -279,16 +280,21 @@ class DefaultCollator(PackedMixin):
                 return_tensors=self.return_tensors,
                 truncation=True,
                 pad_to_multiple_of=self.pad_to_multiple_of,
+                add_special_tokens=False,
             )
         else:
             tokenized_labels = self.tokenizer(
-                labels, padding="longest", return_tensors=self.return_tensors
+                labels,
+                padding="longest",
+                return_tensors=self.return_tensors,
+                add_special_tokens=False,
             )
             tokenized_sources = self.tokenizer(
                 sources,
                 padding="longest",
                 return_tensors=self.return_tensors,
                 pad_to_multiple_of=self.pad_to_multiple_of,
+                add_special_tokens=False,
             )
         label_mask = tokenized_labels["attention_mask"].bool()
         masked_labels = tokenized_labels["input_ids"].masked_fill(
@@ -326,6 +332,7 @@ class DefaultCollator(PackedMixin):
             return output_batch
 
         if self.max_input_length > 0:
+            # make sure we truncate sources...labels if needed
             if self.tokenizer.truncation_side == "left":
                 tokenized_labels = self.tokenizer(
                     labels,
@@ -333,6 +340,7 @@ class DefaultCollator(PackedMixin):
                     padding=self.padding,
                     return_tensors=self.return_tensors,
                     truncation=True,
+                    add_special_tokens=False,
                 )
             else:
                 tokenized_sources = self.tokenizer(
@@ -341,6 +349,7 @@ class DefaultCollator(PackedMixin):
                     padding=self.padding,
                     return_tensors=self.return_tensors,
                     truncation=True,
+                    add_special_tokens=False,
                 )
 
             tok_sources_plus_labels = self.tokenizer(
@@ -350,18 +359,21 @@ class DefaultCollator(PackedMixin):
                 return_tensors=self.return_tensors,
                 truncation=True,
                 pad_to_multiple_of=self.pad_to_multiple_of,
+                add_special_tokens=False,
             )
         else:
             tokenized_sources = self.tokenizer(
                 sources,
                 padding="longest",
                 return_tensors=self.return_tensors,
+                add_special_tokens=False,
             )
             tok_sources_plus_labels = self.tokenizer(
                 [i + t for i, t in zip(sources, labels)],
                 padding="longest",
                 return_tensors=self.return_tensors,
                 pad_to_multiple_of=self.pad_to_multiple_of,
+                add_special_tokens=False,
             )
 
         targets = tok_sources_plus_labels["input_ids"].clone()


### PR DESCRIPTION
- We leave adding special tokens to the user, our collator shouldn't handle that to avoid problems when passing chat templated formatted sequences
- We also remove the space between labels and eos.